### PR TITLE
allow custom class and style props

### DIFF
--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -1,5 +1,6 @@
 'use strict';
 
+import className from 'classnames';
 import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -69,7 +70,9 @@ export default class Accordion extends Component {
 
   render() {
     return (
-      <div className="react-sanfona" role="tablist">
+      <div className={className('react-sanfona', this.props.className)}
+        role="tablist"
+        style={this.props.style}>
         {this.renderItems()}
       </div>
     );
@@ -87,5 +90,7 @@ Accordion.propTypes = {
   activeItems: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.array
-  ])
+  ]),
+  className: PropTypes.string,
+  style: PropTypes.object
 };

--- a/src/AccordionItem/index.jsx
+++ b/src/AccordionItem/index.jsx
@@ -76,9 +76,12 @@ export default class AccordionItem extends Component {
     var props = {
       className: className([
         'react-sanfona-item',
-        { 'react-sanfona-item-expanded': this.props.expanded }
+        this.props.className,
+        { 'react-sanfona-item-expanded': this.props.expanded },
+        { [this.props.expandedClassName]: this.props.expanded }
       ]),
-      role: 'tabpanel'
+      role: 'tabpanel',
+      style: this.props.style
     };
 
     if (this.props.expanded) {
@@ -94,11 +97,13 @@ export default class AccordionItem extends Component {
     return (
       <div {...this.getProps()} ref="item">
         <AccordionItemTitle
+          className={this.props.titleClassName}
           title={this.props.title}
           onClick={this.props.onClick}
           titleColor= {this.props.titleColor}
           uuid={this.uuid} />
         <AccordionItemBody maxHeight={this.state.maxHeight}
+          className={this.props.bodyClassName}
           overflow={this.state.overflow}
           ref="body"
           uuid={this.uuid}>
@@ -111,7 +116,12 @@ export default class AccordionItem extends Component {
 }
 
 AccordionItem.propTypes = {
+  bodyClassName: PropTypes.string,
+  className: PropTypes.string,
   expanded: PropTypes.bool,
   onClick: PropTypes.func,
-  title: PropTypes.string
+  title: PropTypes.string,
+  expandedClassName: PropTypes.string,
+  style: PropTypes.object,
+  titleClassName: PropTypes.string
 };

--- a/src/AccordionItemBody/index.jsx
+++ b/src/AccordionItemBody/index.jsx
@@ -1,5 +1,6 @@
 'use strict';
 
+import className from 'classnames';
 import React, { Component, PropTypes } from 'react';
 
 export default class AccordionItemBody extends Component {
@@ -13,7 +14,7 @@ export default class AccordionItemBody extends Component {
 
     return (
       <div aria-labelledby={`react-safona-item-title-${ this.props.uuid }`}
-        className="react-sanfona-item-body"
+        className={className('react-sanfona-item-body', this.props.className)}
         id={`react-safona-item-body-${ this.props.uuid }`}
         style={style}>
         <div className="react-sanfona-item-body-wrapper">
@@ -26,6 +27,7 @@ export default class AccordionItemBody extends Component {
 }
 
 AccordionItemBody.propTypes = {
+  className: PropTypes.string,
   maxHeight: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number

--- a/src/AccordionItemTitle/index.jsx
+++ b/src/AccordionItemTitle/index.jsx
@@ -1,5 +1,6 @@
 'use strict';
 
+import className from 'classnames';
 import React, { Component, PropTypes } from 'react';
 
 export default class AccordionItemTitle extends Component {
@@ -13,7 +14,7 @@ export default class AccordionItemTitle extends Component {
 
     return (
       <h3 aria-controls={`react-sanfona-item-body-${ this.props.uuid }`}
-        className="react-sanfona-item-title"
+        className={className('react-sanfona-item-title', this.props.className)}
         id={`react-safona-item-title-${ this.props.uuid }`}
         onClick={this.props.onClick}
         style={style}>
@@ -25,6 +26,7 @@ export default class AccordionItemTitle extends Component {
 }
 
 AccordionItemTitle.propTypes = {
+  className: PropTypes.string,
   onClick: PropTypes.func,
   title: PropTypes.string,
   uuid: PropTypes.string


### PR DESCRIPTION
potentially fixes #54
adding class names to everything seems sensible, and style on outer elements if it is wanted. I didn't want to add style to ItemTitle and ItemBody because
a) AccordionItem props are getting pretty busy
b) Could break things if overriding max-height on body, for example

Happy to remove style props entirely if you think it's better, mainly added because they were specified in the issue and css-in-js people might enjoy it