### PR TITLE
Fix for `Uncaught Type Issue` when this.props.children is an object and not an array

### DIFF
--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -56,6 +56,16 @@ export default class Accordion extends Component {
       return null;
     }
 
+    if (!Array.isArray(this.props.children)) {
+      const expanded = !this.props.disabled && this.state.activeItems.indexOf(0) !== -1;
+      return React.cloneElement(this.props.children, {
+        expanded: expanded,
+        key: 0,
+        onClick: this.handleClick.bind(this, 0, this.props.children.props.onClick),
+        ref: `item-${ 0 }`
+      });
+    }
+
     return this.props.children.map((item, index) => {
       const expanded = this.state.activeItems.indexOf(index) !== -1;
 

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -58,6 +58,7 @@ export default class Accordion extends Component {
 
     if (!Array.isArray(this.props.children)) {
       const expanded = !this.props.disabled && this.state.activeItems.indexOf(0) !== -1;
+
       return React.cloneElement(this.props.children, {
         expanded: expanded,
         key: 0,


### PR DESCRIPTION
+ When rendering a single `AccordionItem`, `this.props.children` is an object and not an array. 
+ `renderItems()` now handles `this.props.children` if it's an object by checking if `this.props.children` is an array.