### PR TITLE
Allow indexing AccordionItems by string

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import { Accordion, AccordionItem } from 'react-sanfona';
 			<Accordion>
 				{[1, 2, 3, 4, 5].map((item) => {
 					return (
-						<AccordionItem title={`Item ${ item }`} key={item}>
+						<AccordionItem title={`Item ${ item }`} slug={item} key={item}>
 							<div>
 								{`Item ${ item } content`}
 								{item === 3 ? <p><img src="https://cloud.githubusercontent.com/assets/38787/8015584/2883817e-0bda-11e5-9662-b7daf40e8c27.gif" /></p> : null}
@@ -99,9 +99,16 @@ Then:
 
 ## options / PropTypes
 
+#### Accordion
 * **allowMultiple:** allow multiple items to be open at the same time (default: false)
 * **activeItems:** receives either an array of indexes or a single index. Each index corresponds to the item order, starting from 0. Ex: activeItems={0}, activeItems=[0, 1, 2]
 * **onChange:** function with the new state as an argument
+
+#### AccordionItem
+* **title:** Text to display in header
+* **slug:** Key used in activeItems lookup
+* **expanded:** Expand item body
+* **className:** Custom class for this item. Also have **bodyClassName**, **expandedClassName**, & **titleClassName**
 
 ## development
 

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -18,9 +18,9 @@ class Demo extends React.Component {
         <h2>Default settings</h2>
 
         <Accordion>
-          {[1, 2, 3, 4, 5].map((item) => {
+          {[1, 'two', 3, 'four', 5].map((item) => {
             return (
-              <AccordionItem title={`Item ${ item }`} key={item}>
+              <AccordionItem title={`Item ${ item }`} slug={item} key={item}>
                 <div>
                   {`Item ${ item } content`}
                   {item === 3 ? <p><img src="https://cloud.githubusercontent.com/assets/38787/8015584/2883817e-0bda-11e5-9662-b7daf40e8c27.gif" /></p> : null}

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -4,16 +4,15 @@ import className from 'classnames';
 import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 
+const arrayify = obj => [].concat(obj);
+
 export default class Accordion extends Component {
 
   constructor(props) {
     super(props);
-
-    let activeItems = !Array.isArray(props.activeItems) ?
-                      [props.activeItems] :
-                      props.activeItems;
-
-    this.state = { activeItems: activeItems };
+    this.state = {
+      activeItems: arrayify(props.activeItems)
+    };
   }
 
   componentDidMount() {
@@ -60,18 +59,8 @@ export default class Accordion extends Component {
       return null;
     }
 
-    if (!Array.isArray(this.props.children)) {
-      const expanded = !this.props.disabled && this.state.activeItems.indexOf(0) !== -1;
-
-      return React.cloneElement(this.props.children, {
-        expanded: expanded,
-        key: 0,
-        onClick: this.handleClick.bind(this, 0, this.props.children.props.onClick),
-        ref: `item-${ 0 }`
-      });
-    }
-
-    return this.props.children.map((item, index) => {
+    const children = arrayify(this.props.children);
+    return children.map((item, index) => {
       const expanded = this.state.activeItems.indexOf(index) !== -1;
 
       return React.cloneElement(item, {

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -10,8 +10,13 @@ export default class Accordion extends Component {
 
   constructor(props) {
     super(props);
+    let activeItems = arrayify(props.activeItems);
+
+    // can't have multiple active items, just use the first one
+    if (!props.allowMultiple) activeItems = [activeItems[0]]
+
     this.state = {
-      activeItems: arrayify(props.activeItems)
+      activeItems
     };
   }
 
@@ -20,14 +25,6 @@ export default class Accordion extends Component {
       if (this.refs[`item-${ index }`]) {
         this.refs[`item-${ index }`].allowOverflow();
       }
-    });
-
-    // allow overflow for absolute positioned elements inside
-    // the item body, but only after animation is complete
-    ReactDOM.findDOMNode(this).addEventListener('transitionend', () => {
-      this.state.activeItems.forEach((index) => {
-        this.refs[`item-${ index }`].allowOverflow();
-      });
     });
   }
 
@@ -61,13 +58,14 @@ export default class Accordion extends Component {
 
     const children = arrayify(this.props.children);
     return children.map((item, index) => {
-      const expanded = this.state.activeItems.indexOf(index) !== -1;
+      const key = item.props.slug || index;
+      const expanded = this.state.activeItems.indexOf(key) !== -1;
 
       return React.cloneElement(item, {
         expanded: expanded,
-        key: index,
-        onClick: this.handleClick.bind(this, index),
-        ref: `item-${ index }`
+        key: key,
+        onClick: this.handleClick.bind(this, key),
+        ref: `item-${ key }`
       });
     });
   }

--- a/src/Accordion/test.jsx
+++ b/src/Accordion/test.jsx
@@ -89,8 +89,6 @@ describe('Accordion Test Case', () => {
     });
   });
 
-  // todo: should init with only one activeItem when allowMultiple is false
-
   describe('allowMultiple', () => {
 
     it('should allow multiple expanded items', () => {

--- a/src/Accordion/test.jsx
+++ b/src/Accordion/test.jsx
@@ -55,19 +55,19 @@ describe('Accordion Test Case', () => {
       expect(items[1].props.expanded, 'to be true');
     });
 
-    it('should accept multiple selected indexes', () => {
+    it('should accept a string as active item prop', () => {
       const tree = sd.shallowRender(
-        <Accordion activeItems={[0, 1]}>
-          <AccordionItem title="First" />
-          <AccordionItem title="Second" />
+        <Accordion activeItems={'second'}>
+          <AccordionItem title="First" slug='first' />
+          <AccordionItem title="Second" slug='second' />
         </Accordion>
-      );
+      )
 
       vdom = tree.getRenderOutput();
 
       items = tree.props.children;
 
-      expect(items[0].props.expanded, 'to be true');
+      expect(items[0].props.expanded, 'to be false');
       expect(items[1].props.expanded, 'to be true');
     });
 
@@ -87,8 +87,9 @@ describe('Accordion Test Case', () => {
 
       expect(instance.state.activeItems, 'to equal', [0]);
     });
-
   });
+
+  // todo: should init with only one activeItem when allowMultiple is false
 
   describe('allowMultiple', () => {
 
@@ -111,6 +112,38 @@ describe('Accordion Test Case', () => {
 
       vdom = tree.getRenderOutput();
       items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be true');
+      expect(items[1].props.expanded, 'to be true');
+    });
+
+    it('should default to first active item if allowMultiple is false', () => {
+      const tree = sd.shallowRender(
+        <Accordion activeItems={[0, 1]}>
+          <AccordionItem title="First" />
+          <AccordionItem title="Second" />
+        </Accordion>
+      );
+
+      vdom = tree.getRenderOutput();
+
+      items = tree.props.children;
+
+      expect(items[0].props.expanded, 'to be true');
+      expect(items[1].props.expanded, 'to be false');
+    });
+
+    it('should allow multiple selected indexes of different types', () => {
+      const tree = sd.shallowRender(
+        <Accordion activeItems={[0, 'second']} allowMultiple>
+          <AccordionItem title="First" />
+          <AccordionItem title="Second" slug="second" />
+        </Accordion>
+      );
+
+      vdom = tree.getRenderOutput();
+
+      items = tree.props.children;
 
       expect(items[0].props.expanded, 'to be true');
       expect(items[1].props.expanded, 'to be true');

--- a/src/AccordionItem/index.jsx
+++ b/src/AccordionItem/index.jsx
@@ -24,6 +24,11 @@ export default class AccordionItem extends Component {
 
   componentDidMount() {
     this.setMaxHeight();
+    // allow overflow for absolute positioned elements inside
+    // the item body, but only after animation is complete
+    ReactDOM.findDOMNode(this).addEventListener('transitionend', () => {
+      if (this.props.expanded) this.allowOverflow();
+    });
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
`slug` prop on AccordionItem to allow indexing by a string instead of just index number

also prevents initialising accordion with multiple activeItems unless activeItems is `true`

fixes #66 