### PR TITLE
Extending Accordion and AccordionItem functionality and updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,22 +100,32 @@ Then:
 ## options / PropTypes
 
 #### Accordion
-* **allowMultiple:** allow multiple items to be open at the same time (default: false)
-* **activeItems:** receives either an array of indexes or a single index. Each index corresponds to the item order, starting from 0. Ex: activeItems={0}, activeItems=[0, 1, 2]
-* **onChange:** function with the new state as an argument
+| Property | Type | Description | Default |
+|:---|:---|:---|
+| allowMultiple | `Boolean` | Allow multiple items to be open at the same time. | `false` |
+| activeItems | `Array` | Receives either an array of indexes or a single index. Each index corresponds to the item order, starting from 0. Ex: activeItems={0}, activeItems=[0, 1, 2] | `[0]` |
+| openNextAccordionItem | `Boolean` | Opens the next accordion item after the previous one is closed. Defaults first one as active and applies for each accordion item except the last one. Not compatible when passing in a custom slug | `false` |
+| onChange | `Function` | Triggered when component updates and passes new state as an argument | `null` |
 
 #### AccordionItem
-* **title:** Text to display in header
-* **slug:** Key used in activeItems lookup
-* **expanded:** Expand item body
-* **className:** Custom class for this item. Also have **bodyClassName**, **expandedClassName**, & **titleClassName**
+| Property | Type | Description | Default |
+|:---|:---|:---|
+| title | `String` | Text to display in header. | `null` |
+| slug | `String/Number` | Key used in activeItems lookup | `null` |
+| expanded | `Boolean` | If item body should be expanded or not | `false` |
+| onExpanded | `Function` | Callback for when item is expanded | `null` |
+| onClosed | `Function` | Callback for when item is closed | `null` |
+| className | `String` | Custom classname applied to root div | `null` |
+| bodyClassName | `String` | Custom classname applied to the accordion item body | `null` |
+| expandedClassName | `String` | Custom classname applied when accordion is expanded | `null` |
+| titleClassName | `String` | Custom classname applied to accordion item header text | `null` |
 
 ## development
 
 ```
 npm install
 
-npm run demo
+npm run demo // served on localhost:8080
 
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Then:
 
 #### Accordion
 | Property | Type | Description | Default |
-|:---|:---|:---|
+|:---|:---|:---|:---|
 | allowMultiple | `Boolean` | Allow multiple items to be open at the same time. | `false` |
 | activeItems | `Array` | Receives either an array of indexes or a single index. Each index corresponds to the item order, starting from 0. Ex: activeItems={0}, activeItems=[0, 1, 2] | `[0]` |
 | openNextAccordionItem | `Boolean` | Opens the next accordion item after the previous one is closed. Defaults first one as active and applies for each accordion item except the last one. Not compatible when passing in a custom slug | `false` |
@@ -111,7 +111,7 @@ Then:
 
 #### AccordionItem
 | Property | Type | Description | Default |
-|:---|:---|:---|
+|:---|:---|:---|:---|
 | title | `String` | Text to display in header. | `null` |
 | slug | `String/Number` | Key used in activeItems lookup | `null` |
 | expanded | `Boolean` | If item body should be expanded or not | `false` |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Then:
 | allowMultiple | `Boolean` | Allow multiple items to be open at the same time. | `false` |
 | activeItems | `Array` | Receives either an array of indexes or a single index. Each index corresponds to the item order, starting from 0. Ex: activeItems={0}, activeItems=[0, 1, 2] | `[0]` |
 | openNextAccordionItem | `Boolean` | Opens the next accordion item after the previous one is closed. Defaults first one as active and applies for each accordion item except the last one. Not compatible when passing in a custom slug | `false` |
+| className | `String` | Custom classname applied to root div | `null` |
+| style | `Object` | Inline styles applied to root div | `null` |
 | onChange | `Function` | Triggered when component updates and passes new state as an argument | `null` |
 
 #### AccordionItem
@@ -114,11 +116,22 @@ Then:
 | slug | `String/Number` | Key used in activeItems lookup | `null` |
 | expanded | `Boolean` | If item body should be expanded or not | `false` |
 | onExpanded | `Function` | Callback for when item is expanded | `null` |
-| onClosed | `Function` | Callback for when item is closed | `null` |
-| className | `String` | Custom classname applied to root div | `null` |
+| onClosed | `Function` | Callback for when item closes | `null` |
+| className | `String` | Custom classname applied to root item div | `null` |
 | bodyClassName | `String` | Custom classname applied to the accordion item body | `null` |
 | expandedClassName | `String` | Custom classname applied when accordion is expanded | `null` |
 | titleClassName | `String` | Custom classname applied to accordion item header text | `null` |
+
+## Styling with classnames
+| Classname | Target |
+|:---|:---|
+| `react-sanfona`| Accordion container |
+| `react-sanfona-item` | AccordionItem container |
+| `react-sanfona-item-expanded` | AccordionItem container when expanded |
+| `react-sanfona-item-title` | AccordionItem header text |
+| `react-sanfona-item-body` | AccordionItem body container |
+| `react-sanfona-item-body-wrapper` | AccordionItem body children wrapper |
+
 
 ## development
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Then:
 | titleClassName | `String` | Custom classname applied to accordion item header text | `null` |
 
 ## Styling with classnames
-| Classname | Target |
+| Classname | Targets |
 |:---|:---|
 | `react-sanfona`| Accordion container |
 | `react-sanfona-item` | AccordionItem container |

--- a/demo/demo.scss
+++ b/demo/demo.scss
@@ -52,6 +52,12 @@ body {
   &-expanded &-title {
     background-color: $primary-color;
     color: #fff;
+
+    .title-done-btn {
+        display: inline-block;
+        float: right;
+        color: #000;
+    }
   }
 
   &-body-wrapper {
@@ -67,6 +73,10 @@ body {
   img {
     display: block;
     max-width: 100%;
+  }
+
+  .title-done-btn {
+      display: none;
   }
 
 }

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -64,8 +64,14 @@ class Demo extends React.Component {
 
         <Accordion openNextAccordionItem>
           {[1, 2, 3, 4, 5].map((item) => {
+            const title = (
+                <span>
+                    <span>{`Item ${ item }`}</span>
+                    <span className='title-done-btn'><button>Done</button></span>
+                </span>
+            );
             return (
-              <AccordionItem title={`Item ${ item }`} key={item} onExpand={() => console.log('expanded')} onClose={() => console.log('closed')}>
+              <AccordionItem title={title} key={item}>
                 <div>
                   {`Item ${ item } content`}
                   {item === 3 ? <p><img src="http://i.giphy.com/nIMpbXH2WfYRi.gif" /></p> : null}

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -60,6 +60,21 @@ class Demo extends React.Component {
           })}
         </Accordion>
 
+        <h2>Open next accordion item</h2>
+
+        <Accordion openNextAccordionItem>
+          {[1, 2, 3, 4, 5].map((item) => {
+            return (
+              <AccordionItem title={`Item ${ item }`} key={item} onExpand={() => console.log('expanded')} onClose={() => console.log('closed')}>
+                <div>
+                  {`Item ${ item } content`}
+                  {item === 3 ? <p><img src="http://i.giphy.com/nIMpbXH2WfYRi.gif" /></p> : null}
+                </div>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
+
         <h2>Overflow example</h2>
 
         <Accordion>

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -34,7 +34,7 @@ export default class Accordion extends Component {
     if (position !== -1) {
       newState.activeItems.splice(position, 1);
 
-      if(this.props.openNextAccordionItem) {
+      if(this.props.openNextAccordionItem && index !== this.props.children.length - 1) {
         newState.activeItems.push(index + 1);
       }
     } else if (this.props.allowMultiple) {
@@ -47,7 +47,7 @@ export default class Accordion extends Component {
       this.props.onChange(newState);
     }
 
-    // removes duplicate items in activeitems array    
+    // removes duplicate items in activeItems array
     newState.activeItems = dedupeArr(newState.activeItems);
     this.setState(newState);
   }
@@ -59,7 +59,7 @@ export default class Accordion extends Component {
 
     const children = arrayify(this.props.children);
     return children.map((item, index) => {
-      const key = item.props.slug || index;
+      const key = this.props.openNextAccordionItem ? index : (item.props.slug || index);
       const expanded = this.state.activeItems.indexOf(key) !== -1;
 
       return React.cloneElement(item, {

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -5,6 +5,9 @@ import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 
 const arrayify = obj => [].concat(obj);
+const dedupeArr = arr => arr.filter((item, index, inputArray) => {
+  return inputArray.indexOf(item) === index;
+});
 
 export default class Accordion extends Component {
 
@@ -30,6 +33,10 @@ export default class Accordion extends Component {
 
     if (position !== -1) {
       newState.activeItems.splice(position, 1);
+
+      if(this.props.openNextAccordionItem) {
+        newState.activeItems.push(index + 1);
+      }
     } else if (this.props.allowMultiple) {
       newState.activeItems.push(index);
     } else {
@@ -40,6 +47,8 @@ export default class Accordion extends Component {
       this.props.onChange(newState);
     }
 
+    // removes duplicate items in activeitems array    
+    newState.activeItems = dedupeArr(newState.activeItems);
     this.setState(newState);
   }
 

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -5,6 +5,8 @@ import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 
 const arrayify = obj => [].concat(obj);
+
+// removes duplicate from array
 const dedupeArr = arr => arr.filter((item, index, inputArray) => {
   return inputArray.indexOf(item) === index;
 });

--- a/src/Accordion/test.jsx
+++ b/src/Accordion/test.jsx
@@ -179,4 +179,103 @@ describe('Accordion Test Case', () => {
 
   });
 
+  describe('openNextAccordionItem', () => {
+
+    it('should open next accordion item', () => {
+      const tree = sd.shallowRender(
+        <Accordion openNextAccordionItem>
+          <AccordionItem title="First" />
+          <AccordionItem title="Second" />
+        </Accordion>
+      );
+
+      instance = tree.getMountedInstance();
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be true');
+      expect(items[1].props.expanded, 'to be false');
+
+      instance.handleClick(0);
+
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be false');
+      expect(items[1].props.expanded, 'to be true');
+    });
+
+    it('should close last item and not open another accordion item', () => {
+      const tree = sd.shallowRender(
+        <Accordion openNextAccordionItem activeItems={[1]}>
+          <AccordionItem title="First" />
+          <AccordionItem title="Second" />
+        </Accordion>
+      );
+
+      instance = tree.getMountedInstance();
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be false');
+      expect(items[1].props.expanded, 'to be true');
+
+      instance.handleClick(1);
+
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be false');
+      expect(items[1].props.expanded, 'to be false');
+    });
+
+    it('should open multiple if allowMultiple present', () => {
+      const tree = sd.shallowRender(
+        <Accordion openNextAccordionItem allowMultiple>
+          <AccordionItem title="First" />
+          <AccordionItem title="Second" />
+          <AccordionItem title="Third" />
+        </Accordion>
+      );
+
+      instance = tree.getMountedInstance();
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be true');
+      expect(items[1].props.expanded, 'to be false');
+      expect(items[2].props.expanded, 'to be false');
+
+      instance.handleClick(1);
+      instance.handleClick(2);
+
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be true');
+      expect(items[1].props.expanded, 'to be true');
+      expect(items[2].props.expanded, 'to be true');
+    });
+
+    it('should override slug property and assign key to index', () => {
+      const tree = sd.shallowRender(
+        <Accordion openNextAccordionItem>
+          <AccordionItem title="First" slug='first' />
+          <AccordionItem title="Second" slug='second' />
+        </Accordion>
+      );
+
+      instance = tree.getMountedInstance();
+
+      instance.handleClick(0);
+
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.expanded, 'to be false');
+      expect(items[1].props.expanded, 'to be true');
+    });
+
+  });
+
 });

--- a/src/AccordionItem/index.jsx
+++ b/src/AccordionItem/index.jsx
@@ -54,20 +54,36 @@ export default class AccordionItem extends Component {
   }
 
   handleExpand() {
+    const { onExpand } = this.props;
+
     this.startTransition();
-    this.timeout = setTimeout(() => this.setState({
-      maxHeight: 'none',
-      overflow: 'visible'
-    }), this.state.duration);
+    this.timeout = setTimeout(() => {
+      this.setState({
+        maxHeight: 'none',
+        overflow: 'visible'
+      });
+
+      if(onExpand) {
+        onExpand();
+      }
+
+    }, this.state.duration);
   }
 
   handleCollapse() {
+    const { onClose } = this.props;
+
     this.startTransition();
     this.timeout = setTimeout(() => {
       this.setState({
         maxHeight: 0,
         overflow: 'hidden'
       });
+
+      if(onClose) {
+        onClose();
+      }
+
     }, 0);
   }
 


### PR DESCRIPTION
Hi!

Extended the functionality for the Accordion and AccordionItem components. It should not cause a conflict for existing users. I detailed my changes below.

Prop updates
Accordion
+ openNextAccordionItem - opens the next accordion item when closing the currently expanded one.  Here is a demo: https://cl.ly/0K1P0S133K0O

AccordionItem 
+ onExpanded - fires a callback when an accordion item has expanded
+ onClosed - fires a callback when accordion item has closed

Updates to README
+ Added markdown tables to identify props, description, type, and defaults values for Accordion and AccordionItem components
+ Added markdown table for styling using classnames. Shows the classname and what it targets

Let me know if anyone has any feedback! 👍🏽