### PR TITLE
fix method names for onExpanded and onClosed callbacks

### DIFF
--- a/src/AccordionItem/index.jsx
+++ b/src/AccordionItem/index.jsx
@@ -54,7 +54,7 @@ export default class AccordionItem extends Component {
   }
 
   handleExpand() {
-    const { onExpand } = this.props;
+    const { onExpanded } = this.props;
 
     this.startTransition();
     this.timeout = setTimeout(() => {
@@ -63,15 +63,15 @@ export default class AccordionItem extends Component {
         overflow: 'visible'
       });
 
-      if(onExpand) {
-        onExpand();
+      if(onExpanded) {
+        onExpanded();
       }
 
     }, this.state.duration);
   }
 
   handleCollapse() {
-    const { onClose } = this.props;
+    const { onClosed } = this.props;
 
     this.startTransition();
     this.timeout = setTimeout(() => {
@@ -80,8 +80,8 @@ export default class AccordionItem extends Component {
         overflow: 'hidden'
       });
 
-      if(onClose) {
-        onClose();
+      if(onClosed) {
+        onClosed();
       }
 
     }, 0);


### PR DESCRIPTION
These methods weren't work.

Changed method names in `AccordionItem` component

| Property | Type | Description | Default |
|:---|:---|:---|:---|
| onExpanded | `Function` | Callback for when item is expanded | `null` |
| onClosed | `Function` | Callback for when item closes | `null` |