### PR TITLE
Allow override of html tags with props

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ Then:
 | allowMultiple | `Boolean` | Allow multiple items to be open at the same time. | `false` |
 | activeItems | `Array` | Receives either an array of indexes or a single index. Each index corresponds to the item order, starting from 0. Ex: activeItems={0}, activeItems=[0, 1, 2] | `[0]` |
 | openNextAccordionItem | `Boolean` | Opens the next accordion item after the previous one is closed. Defaults first one as active and applies for each accordion item except the last one. Not compatible when passing in a custom slug | `false` |
-| className | `String` | Custom classname applied to root div | `null` |
-| style | `Object` | Inline styles applied to root div | `null` |
+| className | `String` | Custom classname applied to root element | `null` |
+| style | `Object` | Inline styles applied to root element | `null` |
 | onChange | `Function` | Triggered when component updates and passes new state as an argument | `null` |
+| rootTag | `String` | Custom HTML tag used for root element | `'div'` |
 
 #### AccordionItem
 | Property | Type | Description | Default |
@@ -117,12 +118,15 @@ Then:
 | expanded | `Boolean` | If item body should be expanded or not | `false` |
 | onExpand | `Function` | Callback for when item is expanded | `null` |
 | onClose | `Function` | Callback for when item closes | `null` |
-| className | `String` | Custom classname applied to root item div | `null` |
+| className | `String` | Custom classname applied to root item element | `null` |
 | bodyClassName | `String` | Custom classname applied to the accordion item body | `null` |
 | expandedClassName | `String` | Custom classname applied when accordion is expanded | `null` |
 | titleClassName | `String` | Custom classname applied to accordion item header text | `null` |
 | disabled | `Boolean` | If item should be expanded or not | `false` |
 | disabledClassName | `String` | Custom classname applied to accordion item header text when item is disabled | `null` |
+| rootTag | `String` | Custom HTML tag used for root element | `'div'` |
+| titleTag | `String` | Custom HTML tag used for title element | `'h3'` |
+| bodyTag | `String` | Custom HTML tag used for body element | `'div'` |
 
 ## Styling with classnames
 | Classname | Targets |

--- a/src/Accordion/index.jsx
+++ b/src/Accordion/index.jsx
@@ -91,13 +91,13 @@ export default class Accordion extends Component {
 
   render() {
     return (
-      <div
+      <this.props.rootTag
         className={className('react-sanfona', this.props.className)}
         role="tablist"
         style={this.props.style}
       >
         {this.renderItems()}
-      </div>
+      </this.props.rootTag>
     );
   }
 }
@@ -105,6 +105,7 @@ export default class Accordion extends Component {
 Accordion.defaultProps = {
   activeItems: [0],
   allowMultiple: false,
+  rootTag: 'div',
 };
 
 Accordion.propTypes = {
@@ -113,4 +114,5 @@ Accordion.propTypes = {
   className: PropTypes.string,
   onChange: PropTypes.func,
   style: PropTypes.object,
+  rootTag: PropTypes.string,
 };

--- a/src/Accordion/test.jsx
+++ b/src/Accordion/test.jsx
@@ -19,6 +19,18 @@ describe('Accordion Test Case', () => {
 
     expect(instance, 'to be defined');
     expect(vdom, 'to be defined');
+    expect(vdom.type, 'to be', 'div');
+  });
+
+  it('should render with a custom tag', () => {
+    const tree = sd.shallowRender(<Accordion rootTag="ul" />);
+
+    instance = tree.getMountedInstance();
+    vdom = tree.getRenderOutput();
+
+    expect(instance, 'to be defined');
+    expect(vdom, 'to be defined');
+    expect(vdom.type, 'to be', 'ul');
   });
 
   describe('activeItems', () => {

--- a/src/AccordionItem/index.jsx
+++ b/src/AccordionItem/index.jsx
@@ -130,12 +130,13 @@ export default class AccordionItem extends Component {
 
   render() {
     return (
-      <div {...this.getProps()} ref="item">
+      <this.props.rootTag {...this.getProps()} ref="item">
         <AccordionItemTitle
           className={this.props.titleClassName}
           title={this.props.title}
           onClick={this.props.disabled ? null : this.props.onClick}
           titleColor={this.props.titleColor}
+          rootTag={this.props.titleTag}
           uuid={this.uuid}
         />
         <AccordionItemBody
@@ -144,14 +145,21 @@ export default class AccordionItem extends Component {
           className={this.props.bodyClassName}
           overflow={this.state.overflow}
           ref="body"
+          rootTag={this.props.bodyTag}
           uuid={this.uuid}
         >
           {this.props.children}
         </AccordionItemBody>
-      </div>
+      </this.props.rootTag>
     );
   }
 }
+
+AccordionItem.defaultProps = {
+  rootTag: 'div',
+  titleTag: 'h3',
+  bodyTag: 'div'
+};
 
 AccordionItem.propTypes = {
   bodyClassName: PropTypes.string,
@@ -165,4 +173,7 @@ AccordionItem.propTypes = {
   disabled: PropTypes.bool,
   disabledClassName: PropTypes.string,
   uuid: PropTypes.string,
+  rootTag: PropTypes.string,
+  titleTag: PropTypes.string,
+  bodyTag: PropTypes.string,
 };

--- a/src/AccordionItem/test.jsx
+++ b/src/AccordionItem/test.jsx
@@ -22,6 +22,21 @@ describe('AccordionItem Test Case', () => {
 
     expect(instance, 'to be defined');
     expect(vdom, 'to be defined');
+    expect(vdom.type, 'to be', 'div');
+    expect(vdom.props.children[0].props, 'to have property', 'rootTag', 'h3');
+    expect(vdom.props.children[1].props, 'to have property', 'rootTag', 'div');
+  });
+
+  it('should render with custom tags', () => {
+    const tree = sd.shallowRender(<AccordionItem rootTag="li" titleTag="h2" bodyTag="ul" />);
+    instance = tree.getMountedInstance();
+    vdom = tree.getRenderOutput();
+
+    expect(instance, 'to be defined');
+    expect(vdom, 'to be defined');
+    expect(vdom.type, 'to be', 'li');
+    expect(vdom.props.children[0].props, 'to have property', 'rootTag', 'h2');
+    expect(vdom.props.children[1].props, 'to have property', 'rootTag', 'ul');
   });
 
   it('should have an unique id', () => {

--- a/src/AccordionItemBody/index.jsx
+++ b/src/AccordionItemBody/index.jsx
@@ -13,7 +13,7 @@ export default class AccordionItemBody extends Component {
     };
 
     return (
-      <div
+      <this.props.rootTag
         aria-labelledby={`react-safona-item-title-${this.props.uuid}`}
         className={className('react-sanfona-item-body', this.props.className)}
         id={`react-safona-item-body-${this.props.uuid}`}
@@ -22,9 +22,13 @@ export default class AccordionItemBody extends Component {
         <div className="react-sanfona-item-body-wrapper">
           {this.props.children}
         </div>
-      </div>
+      </this.props.rootTag>
     );
   }
+}
+
+AccordionItemBody.defaultProps = {
+  rootTag: 'div'
 }
 
 AccordionItemBody.propTypes = {
@@ -36,4 +40,5 @@ AccordionItemBody.propTypes = {
   duration: PropTypes.number,
   overflow: PropTypes.string,
   uuid: PropTypes.string,
+  rootTag: PropTypes.string,
 };

--- a/src/AccordionItemTitle/index.jsx
+++ b/src/AccordionItemTitle/index.jsx
@@ -23,7 +23,7 @@ export default class AccordionItemTitle extends Component {
     }
 
     return (
-      <h3
+      <this.props.rootTag
         aria-controls={`react-sanfona-item-body-${this.props.uuid}`}
         className={className('react-sanfona-item-title', this.props.className)}
         id={`react-safona-item-title-${this.props.uuid}`}
@@ -31,9 +31,13 @@ export default class AccordionItemTitle extends Component {
         style={style}
       >
         {title}
-      </h3>
+      </this.props.rootTag>
     );
   }
+}
+
+AccordionItemTitle.defaultProps = {
+  rootTag: 'h3'
 }
 
 AccordionItemTitle.propTypes = {
@@ -41,4 +45,5 @@ AccordionItemTitle.propTypes = {
   onClick: PropTypes.func,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   uuid: PropTypes.string,
+  rootTag: PropTypes.string,
 };


### PR DESCRIPTION
I wanted to use react-sanfona in a project where I was prohibited from altering the existing markup and this custom-tags feature allowed me to do so. I think it might be useful for others, too.