### PR TITLE
Remove reference to React.PropTypes

### DIFF
--- a/src/AccordionItemBody/index.jsx
+++ b/src/AccordionItemBody/index.jsx
@@ -30,8 +30,8 @@ export default class AccordionItemBody extends Component {
 AccordionItemBody.propTypes = {
   className: PropTypes.string,
   maxHeight: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
+      PropTypes.string,
+      PropTypes.number
   ]),
   duration: PropTypes.number,
   overflow: PropTypes.string,


### PR DESCRIPTION
I removed a couple remaining references to React.PropTypes not removed by commit 071cc69.