### PR TITLE
AccordionItemBody should be hidden when not expanded. aria-expanded s…

### DIFF
--- a/src/AccordionItem/index.js
+++ b/src/AccordionItem/index.js
@@ -175,6 +175,7 @@ export default class AccordionItem extends Component {
       <Root {...this.getProps()} ref="item">
         <AccordionItemTitle
           className={titleClassName}
+          expanded={this.props.expanded}
           onClick={disabled ? null : onClick}
           rootTag={titleTag}
           title={title}

--- a/src/AccordionItemBody/index.js
+++ b/src/AccordionItemBody/index.js
@@ -8,7 +8,7 @@ export default class AccordionItemBody extends Component {
 
   getProps() {
     const props = {
-      [`hidden`]: !this.props.expanded
+      'hidden': !this.props.expanded
     };
 
     return props;

--- a/src/AccordionItemBody/index.js
+++ b/src/AccordionItemBody/index.js
@@ -8,7 +8,7 @@ export default class AccordionItemBody extends Component {
 
   getProps() {
     const props = {
-      [`aria-${this.props.expanded ? 'expanded' : 'hidden'}`]: true
+      [`hidden`]: !this.props.expanded
     };
 
     return props;

--- a/src/AccordionItemBody/test.js
+++ b/src/AccordionItemBody/test.js
@@ -10,18 +10,16 @@ describe('AccordionItemBody Test Case', () => {
   let vdom;
 
   describe('aria', () => {
-    it('should set aria-expanded to true when expanded prop is true', () => {
+    it('should set hidden to false when expanded prop is true', () => {
       const tree = sd.shallowRender(<AccordionItemBody expanded />);
       vdom = tree.getRenderOutput();
-      expect(vdom.props['aria-expanded'], 'to be true');
-      expect(vdom.props['aria-hidden'], 'to be undefined');
+      expect(vdom.props['hidden'], 'to be false');
     });
 
-    it('should set aria-hidden to true when expanded prop is not true', () => {
+    it('should set hidden to true when expanded prop is not true', () => {
       const tree = sd.shallowRender(<AccordionItemBody />);
       vdom = tree.getRenderOutput();
-      expect(vdom.props['aria-expanded'], 'to be undefined');
-      expect(vdom.props['aria-hidden'], 'to be true');
+      expect(vdom.props['hidden'], 'to be true');
     });
   });
 

--- a/src/AccordionItemTitle/index.js
+++ b/src/AccordionItemTitle/index.js
@@ -6,10 +6,11 @@ import PropTypes from 'prop-types';
 
 export default function AccordionItemTitle({
   className,
-  uuid,
+  expanded,
   onClick,
   rootTag: Root,
-  title
+  title,
+  uuid
 }) {
   const style = {
     cursor: 'pointer',
@@ -27,6 +28,7 @@ export default function AccordionItemTitle({
   return (
     <Root
       aria-controls={`react-sanfona-item-body-${uuid}`}
+      aria-expanded={expanded}
       className={cx('react-sanfona-item-title', className)}
       id={`react-safona-item-title-${uuid}`}
       onClick={onClick}
@@ -43,6 +45,7 @@ AccordionItemTitle.defaultProps = {
 
 AccordionItemTitle.propTypes = {
   className: PropTypes.string,
+  expanded: PropTypes.bool,
   onClick: PropTypes.func,
   rootTag: PropTypes.string,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/AccordionItemTitle/test.js
+++ b/src/AccordionItemTitle/test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+import expect from 'unexpected';
+import sd from 'skin-deep';
+import React from 'react';
+
+import AccordionItemTitle from './index';
+
+describe('AccordionItemTitle Test Case', () => {
+  let vdom;
+
+  describe('aria', () => {
+    it('should set aria-expanded to true when expanded prop is true', () => {
+      const tree = sd.shallowRender(<AccordionItemTitle expanded />);
+      vdom = tree.getRenderOutput();
+      expect(vdom.props['aria-expanded'], 'to be true');
+    });
+
+    it('should set aria-expanded to false when expanded prop is false', () => {
+      const tree = sd.shallowRender(<AccordionItemTitle expanded={false}/>);
+      vdom = tree.getRenderOutput();
+      expect(vdom.props['aria-expanded'], 'to be false');
+    });
+  });
+
+});


### PR DESCRIPTION
…hould be rendered on AccordianItemTitle