### PR TITLE
Correct 'safona' typo to 'sanfona'

### DIFF
--- a/src/AccordionItemBody/index.js
+++ b/src/AccordionItemBody/index.js
@@ -27,9 +27,9 @@ export default class AccordionItemBody extends Component {
     return (
       <Root
         aria-hidden={!expanded}
-        aria-labelledby={`react-safona-item-title-${uuid}`}
+        aria-labelledby={`react-sanfona-item-title-${uuid}`}
         className={cx('react-sanfona-item-body', className)}
-        id={`react-safona-item-body-${uuid}`}
+        id={`react-sanfona-item-body-${uuid}`}
         style={style}
       >
         <div className="react-sanfona-item-body-wrapper">{children}</div>

--- a/src/AccordionItemTitle/index.js
+++ b/src/AccordionItemTitle/index.js
@@ -20,7 +20,7 @@ export default function AccordionItemTitle({
   if (typeof title === 'object') {
     return React.cloneElement(title, {
       onClick,
-      id: `react-safona-item-title-${uuid}`,
+      id: `react-sanfona-item-title-${uuid}`,
       'aria-controls': `react-sanfona-item-body-${uuid}`
     });
   }
@@ -30,7 +30,7 @@ export default function AccordionItemTitle({
       aria-controls={`react-sanfona-item-body-${uuid}`}
       aria-expanded={expanded}
       className={cx('react-sanfona-item-title', className)}
-      id={`react-safona-item-title-${uuid}`}
+      id={`react-sanfona-item-title-${uuid}`}
       onClick={onClick}
       style={style}
     >


### PR DESCRIPTION
Hi,

Our aXe tests were failing as the id of the body components carry the id 'react-safona-item-body-XXX' (missing 'n'), but are being referred to by an aria-controls element on the trigger with the name including the n. 

Noticed that there was a typo around the title element too, but at least this was consistent with the reference to it :)