### PR TITLE
Adding support to onHover

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ import { Accordion, AccordionItem } from 'react-sanfona';
 | Property | Type | Description | Default |
 |:---|:---|:---|:---|
 | allowMultiple | `Boolean` | Allow multiple items to be open at the same time. | `false` |
+| isHovered | `Boolean` | Allow expanding an element after the mouse hovers an item. | `false` |
 | openNextAccordionItem | `Boolean` | Opens the next accordion item after the previous one is closed. Defaults first one as active and applies for each accordion item except the last one. | `false` |
 | className | `String` | Custom classname applied to root element | `null` |
 | style | `Object` | Inline styles applied to root element | `null` |

--- a/demo/index.js
+++ b/demo/index.js
@@ -13,41 +13,48 @@ class Demo extends React.Component {
     super();
 
     this.state = {
-      activeItems: [0]
+      activeClickedItems: [0],
+      activeHoveredItems: [0]
     };
 
     this.toggleActive = this.toggleActive.bind(this);
-    this.handleChange = this.handleChange.bind(this);
+    this.handleClick = this.handleClick.bind(this);
+    this.handleHover = this.handleHover.bind(this);
   }
 
   toggleActive(index) {
-    const position = this.state.activeItems.indexOf(index);
+    const position = this.state.activeClickedItems.indexOf(index);
 
     if (position !== -1) {
-      this.setState({ activeItems: [] });
+      this.setState({ activeClickedItems: [] });
     } else {
-      this.setState({ activeItems: [index] });
+      this.setState({ activeClickedItems: [index] });
     }
   }
 
-  handleChange({ activeItems }) {
-    this.setState({ activeItems });
+  handleClick({ activeItems }) {
+    this.setState({ activeClickedItems: activeItems });
+  }
+
+  handleHover({ activeItems }) {
+    this.setState({ activeHoveredItems: activeItems });
   }
 
   render() {
+    console.log(this.state);
     return (
       <div className="demo-container">
         <h1>react-sanfona</h1>
 
         <h2>Default settings</h2>
 
-        <Accordion onChange={this.handleChange}>
+        <Accordion>
           {[0, 1, 2, 3, 4].map(item => {
             return (
               <AccordionItem
                 key={item}
                 title={`Item ${item}`}
-                expanded={this.state.activeItems.includes(item)}
+                expanded={this.state.activeClickedItems.includes(item)}
               >
                 <div>
                   {`Item ${item} content`}
@@ -77,6 +84,29 @@ class Demo extends React.Component {
             );
           })}
         </div>
+
+        <h2>Hovered</h2>
+
+        <Accordion onChange={this.handleHover} isHovered>
+          {[0, 1, 2, 3, 4].map(item => {
+            return (
+              <AccordionItem
+                key={item}
+                title={`Item ${item}`}
+                expanded={this.state.activeHoveredItems.includes(item)}
+              >
+                <div>
+                  {`Item ${item} content`}
+                  {item === 2 ? (
+                    <p>
+                      <img src="https://cloud.githubusercontent.com/assets/38787/8015584/2883817e-0bda-11e5-9662-b7daf40e8c27.gif" />
+                    </p>
+                  ) : null}
+                </div>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
 
         <h2>Allow multiple</h2>
 

--- a/src/Accordion/index.js
+++ b/src/Accordion/index.js
@@ -33,7 +33,7 @@ export default class Accordion extends Component {
     }
   }
 
-  handleClick(index) {
+  handleChange(index) {
     const {
       allowMultiple,
       children,
@@ -70,7 +70,7 @@ export default class Accordion extends Component {
   }
 
   renderItems() {
-    const { children, duration, easing } = this.props;
+    const { children, duration, easing, isHovered } = this.props;
 
     if (!children) {
       return null;
@@ -85,13 +85,15 @@ export default class Accordion extends Component {
         } = item;
 
         const isExpanded = !disabled && activeItems.indexOf(index) !== -1;
+        const handleChange = this.handleChange.bind(this, index);
         const element = React.cloneElement(item, {
           duration: itemDuration || duration,
           easing: itemEasing || easing,
           expanded: isExpanded,
           key: index,
           index,
-          onClick: this.handleClick.bind(this, index),
+          onClick: handleChange,
+          onMouseOver: isHovered && !disabled ? handleChange : null,
           ref: `item-${index}`
         });
         acc.push(element);
@@ -129,6 +131,7 @@ Accordion.propTypes = {
   duration: PropTypes.number,
   easing: PropTypes.string,
   onChange: PropTypes.func,
+  isHovered: PropTypes.bool,
   openNextAccordionItem: PropTypes.bool,
   style: PropTypes.object,
   rootTag: PropTypes.string

--- a/src/Accordion/test.js
+++ b/src/Accordion/test.js
@@ -65,6 +65,32 @@ describe('Accordion Test Case', () => {
     });
   });
 
+  describe('onHover items', () => {
+    it('should expand after hover an item', () => {
+      const tree = sd.shallowRender(
+        <Accordion isHovered>
+          <AccordionItem title="First" key={1} expanded />
+          <AccordionItem title="Second" key={2} />
+          <AccordionItem title="Third" key={3} />
+        </Accordion>
+      );
+
+      instance = tree.getMountedInstance();
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+
+      expect(items[0].props.onMouseOver, 'not to be null');
+      expect(items[1].props.onMouseOver, 'not to be null');
+      expect(items[2].props.onMouseOver, 'not to be null');
+
+      items[2].props.onMouseOver(2);
+
+      vdom = tree.getRenderOutput();
+      items = vdom.props.children;
+      expect(items[2].props.expanded, 'to be true');
+    });
+  });
+
   describe('allowMultiple', () => {
     it('should allow multiple expanded items', () => {
       const tree = sd.shallowRender(

--- a/src/Accordion/test.js
+++ b/src/Accordion/test.js
@@ -81,7 +81,7 @@ describe('Accordion Test Case', () => {
       expect(items[0].props.expanded, 'to be false');
       expect(items[1].props.expanded, 'to be true');
 
-      instance.handleClick(0);
+      instance.handleChange(0);
 
       vdom = tree.getRenderOutput();
       items = vdom.props.children;
@@ -147,7 +147,7 @@ describe('Accordion Test Case', () => {
 
       expect(instance.state.activeItems, 'to equal', [1]);
 
-      instance.handleClick(0);
+      instance.handleChange(0);
 
       expect(instance.state.activeItems, 'to equal', [1, 0]);
     });
@@ -164,7 +164,7 @@ describe('Accordion Test Case', () => {
 
       expect(instance.state.activeItems, 'to equal', [1]);
 
-      instance.handleClick(0);
+      instance.handleChange(0);
 
       expect(instance.state.activeItems, 'to equal', [0]);
     });
@@ -186,7 +186,7 @@ describe('Accordion Test Case', () => {
       expect(items[0].props.expanded, 'to be true');
       expect(items[1].props.expanded, 'to be false');
 
-      instance.handleClick(0);
+      instance.handleChange(0);
 
       vdom = tree.getRenderOutput();
       items = vdom.props.children;
@@ -210,7 +210,7 @@ describe('Accordion Test Case', () => {
       expect(items[0].props.expanded, 'to be false');
       expect(items[1].props.expanded, 'to be true');
 
-      instance.handleClick(1);
+      instance.handleChange(1);
 
       vdom = tree.getRenderOutput();
       items = vdom.props.children;
@@ -236,8 +236,8 @@ describe('Accordion Test Case', () => {
       expect(items[1].props.expanded, 'to be false');
       expect(items[2].props.expanded, 'to be false');
 
-      instance.handleClick(1);
-      instance.handleClick(2);
+      instance.handleChange(1);
+      instance.handleChange(2);
 
       vdom = tree.getRenderOutput();
       items = vdom.props.children;
@@ -257,7 +257,7 @@ describe('Accordion Test Case', () => {
 
       instance = tree.getMountedInstance();
 
-      instance.handleClick(0);
+      instance.handleChange(0);
 
       vdom = tree.getRenderOutput();
       items = vdom.props.children;

--- a/src/AccordionItem/index.js
+++ b/src/AccordionItem/index.js
@@ -176,6 +176,7 @@ export default class AccordionItem extends Component {
       duration,
       easing,
       onClick,
+      onMouseOver,
       rootTag: Root,
       title,
       titleClassName,
@@ -190,6 +191,7 @@ export default class AccordionItem extends Component {
           className={titleClassName}
           expanded={this.props.expanded}
           onClick={disabled ? null : onClick}
+          onMouseOver={disabled ? null : onMouseOver}
           rootTag={titleTag}
           title={title}
           uuid={this.uuid}
@@ -234,8 +236,10 @@ AccordionItem.propTypes = {
   expandedClassName: PropTypes.string,
   index: PropTypes.number,
   onClick: PropTypes.func,
+  onMouseOver: PropTypes.func,
   onClose: PropTypes.func,
   onExpand: PropTypes.func,
+  onHover: PropTypes.func,
   rootTag: PropTypes.string,
   slug: PropTypes.string,
   style: PropTypes.object,

--- a/src/AccordionItemTitle/index.js
+++ b/src/AccordionItemTitle/index.js
@@ -8,6 +8,7 @@ export default function AccordionItemTitle({
   className,
   expanded,
   onClick,
+  onMouseOver,
   rootTag: Root,
   title,
   uuid
@@ -32,6 +33,7 @@ export default function AccordionItemTitle({
       className={cx('react-sanfona-item-title', className)}
       id={`react-sanfona-item-title-${uuid}`}
       onClick={onClick}
+      onMouseOver={onMouseOver}
       style={style}
     >
       {title}
@@ -47,6 +49,7 @@ AccordionItemTitle.propTypes = {
   className: PropTypes.string,
   expanded: PropTypes.bool,
   onClick: PropTypes.func,
+  onMouseOver: PropTypes.func,
   rootTag: PropTypes.string,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   uuid: PropTypes.string


### PR DESCRIPTION
Like "onExpand" and "onCollapse" props we can be able to using
isHovered.
This will active automatically expand or collapse my accordion
using onMouseOver event.

Related with #189
- [x] Feature implementation
- [x] Make the unit tests
- [x] Update the documentation

@daviferreira could you give me some advice and help with the code review.
Please correct if I'm making something out the normal :)